### PR TITLE
Allow Python 3.11, switch to `mamba-org/setup-micromamba`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,10 +39,10 @@ jobs:
           ulimit -a
           
       - name: Install conda environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
 
       - name: Install DE-ForceFields

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,7 +27,7 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,4 +41,4 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 
 [options]
-python_requires = >=3.8, <=3.11
+python_requires = >=3.8, <=3.12


### PR DESCRIPTION
* Python 3.11 is generally supported across the OpenFF stack
* https://github.com/MolSSI/cookiecutter-cms/issues/171


I'm using this package in some Interchange tests (installing from source, so I don't need a new release made) and I'm trying to see if this works on Python 3.11. Assuming no surprises this shouldn't be a breaking change.