### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,9 +25,9 @@ jobs:
           - macOS-latest
           - ubuntu-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v3

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,7 +12,7 @@ dependencies:
 
     # Core-deps
   - openff-toolkit >=0.16
-  - openff-interchange >=0.3.25
+  - openff-interchange >=0.4.6
   # the above two constraints are pulled in by smirnoff-plugins;
   # could just drop them, but maybe it's better to be explicit
-  - smirnoff-plugins >=2024.07.0
+  - smirnoff-plugins >=2025.09.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,4 +41,4 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 
 [options]
-python_requires = >=3.10, <3.13
+python_requires = >=3.11, <=3.14


### PR DESCRIPTION
Specifically, ensure interchange>=0.4.6 and smirnoff-plugins>=2025.09.0 as these contain fixes for handling DoubleExponentialVirtualSites.